### PR TITLE
Create a tool to rebuild wasmtests

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,3 @@
 [alias]
 boot = "run --package tools --bin boot"
+buildwasm = "run --package tools --bin buildwasm"

--- a/tools/src/bin/buildwasm.rs
+++ b/tools/src/bin/buildwasm.rs
@@ -1,0 +1,30 @@
+use std::process::{Command, ExitStatus, exit};
+use std::path::{Path, PathBuf};
+use std::io;
+use std::fs;
+
+fn build_wat(wat_file: &Path, wasm_file: &Path) -> io::Result<ExitStatus>  {
+    Command::new("wat2wasm")
+        .arg(wat_file)
+        .arg("-o")
+        .arg(wasm_file)
+        .status()
+}
+
+fn main() {
+    for wat_file in fs::read_dir("wasm").expect("Missing wasm dir") {
+        let wat_file = wat_file.unwrap();
+        let name = wat_file.file_name();
+        let mut wasm_file = PathBuf::from("src/wasm/wasmtests");
+        wasm_file.push(name);
+        wasm_file.set_extension("wasm");
+        let r = build_wat(&wat_file.path(), &wasm_file).unwrap();
+        if !r.success() {
+            match r.code() {
+                Some(x) => eprintln!("wat2wasm exited with status {}", x),
+                None => eprintln!("wat2wasm terminated by signal")
+            };
+            exit(1);
+        }
+    }
+}


### PR DESCRIPTION
Relies on `wabt` being installed on the system, just run `wat2wasm` on everything in `wasm` to produce files in `src/wasm/wasmtests`.