### PR TITLE
Enable QEMU accelerators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ authors = ["Lachlan Sneff <lachlan.sneff@gmail.com>"]
 [package.metadata.bootimage]
 default-target = "x86_64-nebulet.json"
 output = "bootimage.bin"
+run-command = [
+    "qemu-system-x86_64",
+    "-machine", "q35,accel=kvm:xen:hax:tcg",
+    "-drive", "format=raw,file={}"
+]
 
 # We're pulling down the pre-compiled bootloader, so no
 # need to build it. (Also avoids a bug in xargo)


### PR DESCRIPTION
This pull request enables the usage of QEMU's hardware-accelerated virtualization features.

If the host machine has support for KVM / Xen (most Linux PCs do), or HAX (on certain Windows and Mac machines) it will speed up the execution of Nebulet when doing `bootimage run`. Otherwise, it falls back to the slow TCG interpreter / dynamic code generator.