### PR TITLE
Create rust userspace, and print abi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
 
 before_script:
 - rustup component add rust-src
+- rustup target add wasm32-unknown-unknown
 - "(test -x $HOME/.cargo/bin/xargo || cargo install xargo)"
 - "(test -x $HOME/.cargo/bin/bootimage || cargo install bootimage)"
 - "(test -x $HOME/.cargo/bin/cargo-xbuild || cargo install cargo-xbuild)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ exclude = [
     "target/x86_64-nebulet/release/bootloader",
     "target/x86_64-nebulet/debug/bootloader",
     "cretonne",
+    "userspace",
 ]
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+use std::env::remove_var;
+
+fn main() {
+    // Remove sysroot flag... well remove all of them for now.
+    remove_var("RUSTFLAGS");
+
+    let ret = Command::new("cargo")
+        .args(&[
+            "build",
+            "--manifest-path", "userspace/Cargo.toml",
+            "--target", "wasm32-unknown-unknown",
+            "--release",
+        ])
+        .status()
+        .expect("Failed to build userspace");
+
+    assert!(ret.success());
+}

--- a/src/abi/io.rs
+++ b/src/abi/io.rs
@@ -1,0 +1,18 @@
+use object::ProcessRef;
+use nebulet_derive::nebulet_abi;
+use alloc::String;
+
+#[nebulet_abi]
+pub fn print(buffer_offset: u32, buffer_size: u32, process: &ProcessRef) {
+    let instance = process.instance().read();
+    let memory = &instance.memories[0];
+
+    if let Some(buf) = memory.carve_slice(buffer_offset, buffer_size) {
+        // TODO: Make happy path not allocate
+        let s = String::from_utf8_lossy(buf);
+        println!("{}", s);
+    }
+    else {
+        println!("\nPrinting invalid buffer!")
+    }
+}

--- a/src/abi/io.rs
+++ b/src/abi/io.rs
@@ -8,7 +8,6 @@ pub fn print(buffer_offset: u32, buffer_size: u32, process: &ProcessRef) {
     let memory = &instance.memories[0];
 
     if let Some(buf) = memory.carve_slice(buffer_offset, buffer_size) {
-        // TODO: Make happy path not allocate
         let s = String::from_utf8_lossy(buf);
         println!("{}", s);
     }

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -12,3 +12,5 @@ pub mod handle;
 pub mod rand;
 /// Intrinsics
 pub mod intrinsics;
+/// ABIs for I/O
+pub mod io;

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,8 +82,11 @@ pub fn kmain() -> ! {
 
     use object::{ThreadRef, ProcessRef, CodeRef};
 
+    let code = include_bytes!("../userspace/target/wasm32-unknown-unknown/release/hello.wasm");
+
     let thread = ThreadRef::new(1024 * 1024, move || {
-        let code = CodeRef::compile(include_bytes!("wasm/wasmtests/exit.wasm"))
+        // TODO: Hardcoded path is only rebuilt when we build for release mode.
+        let code = CodeRef::compile(code)
             .unwrap();
         for _ in 0..10 {
             let process = ProcessRef::create(code.clone())

--- a/src/wasm/abi.rs
+++ b/src/wasm/abi.rs
@@ -47,4 +47,10 @@ abi_map! {
         returns: I64,
         abi::process::process_start,
     },
+    // I/O
+    print: {
+        params: [I32, I32],
+        returns: VOID,
+        abi::io::print,
+    },
 }

--- a/userspace/.cargo/config
+++ b/userspace/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/userspace/Cargo.lock
+++ b/userspace/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "userspace"
+version = "0.1.0"
+

--- a/userspace/Cargo.toml
+++ b/userspace/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "userspace"
+version = "0.1.0"
+authors = ["morenzg <morenzg@gmail.com>"]
+
+# Fails to build correctly without optimizations.
+[profile.dev]
+opt-level = 3

--- a/userspace/src/bin/hello.rs
+++ b/userspace/src/bin/hello.rs
@@ -1,0 +1,9 @@
+#![no_std]
+#![no_main]
+
+extern crate userspace;
+
+#[no_mangle]
+pub fn main() {
+    userspace::print("Hello world!");
+}

--- a/userspace/src/lib.rs
+++ b/userspace/src/lib.rs
@@ -1,0 +1,35 @@
+#![no_std]
+#![feature(lang_items)]
+#![feature(start)]
+#![feature(wasm_import_module)]
+
+#[lang = "panic_fmt"]
+fn panic_fmt() -> ! {
+    loop {}
+}
+
+#[lang = "oom"]
+fn oom() -> ! {
+    loop {}
+}
+
+// This does nothing but satisfy the rust compiler
+// (well actually it exports a `main` function that calls this, but it doesn't
+// have the type we want it to have).
+#[start]
+pub fn rust_start_not_called(_argc: isize, _argv: *const *const u8) -> isize {
+    0xbadbad
+}
+
+pub mod abi {
+    #[wasm_import_module = "abi"]
+    extern {
+        pub fn print(ptr: *const u8, len: usize);
+    }
+}
+
+pub fn print(x: &str) {
+    unsafe {
+        abi::print(x.as_ptr(), x.len());
+    }
+}


### PR DESCRIPTION
This basically does what it says in the title.

The first commit just creates a print abi function. The only reason it isn't in a seperate pull request is the only way it ever gets tested is the second commit, and the second commit uses it. The only notable thing is it adds the ability to use functions with a return type of `()` in the abi.

The second commit:

 - Modifies nebulet so that in the absence of a proper entry point, it will try and run a function called `main`.
 - Creates a new userspace crate, that includes both a library for interfacing with nebulets abi (incomplete, but easy to extend) and a "hello world" program that prints hello world.
 - Creates a build script that automatically builds the userspace crate, with appropriate cargo flags.