### PR TITLE
Revert "Enable QEMU accelerators"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,6 @@ authors = ["Lachlan Sneff <lachlan.sneff@gmail.com>"]
 [package.metadata.bootimage]
 default-target = "x86_64-nebulet.json"
 output = "bootimage.bin"
-run-command = [
-    "qemu-system-x86_64",
-    "-machine", "q35,accel=kvm:xen:hax:tcg",
-    "-drive", "format=raw,file={}"
-]
 
 [package.metadata.cargo-xbuild]
 memcpy = true


### PR DESCRIPTION
Reverts nebulet/nebulet#43

They require elevated privileges to run and spit out a ton of errors when they don't have said privileges. We need to find a better way to enable kvm when it's an option.