### PR TITLE
Fix building on rustc 1.30.0-nightly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@
     fnbox,
     integer_atomics,
     platform_intrinsics,
-    panic_implementation,
+    panic_handler,
     range_contains,
     stmt_expr_attributes,
     get_type_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,6 @@
     range_contains,
     stmt_expr_attributes,
     get_type_id,
-    iterator_find_map,
     alloc_error_handler,
     const_fn_union,
 )]

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -2,7 +2,7 @@ use core::panic::PanicInfo;
 use arch::cpu::IrqController;
 use arch::interrupt;
 
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub fn panic(info: &PanicInfo) -> ! {
     println!("{}", info);


### PR DESCRIPTION
Solves:

```
error: use of deprecated attribute `panic_implementation`: This attribute was renamed to `panic_handler`. See https://github.com/rust-lang/rust/issues/44489#issuecomment-415140224
 --> src/panic.rs:5:1
```

```
error: the feature `iterator_find_map` has been stable since 1.30.0 and no longer requires an attribute to enable
  --> src/main.rs:29:5
   |
29 |     iterator_find_map,
   |     ^^^^^^^^^^^^^^^^^
```

